### PR TITLE
Abstract away the interface of Interval from the rest of the module

### DIFF
--- a/data-interval.cabal
+++ b/data-interval.cabal
@@ -54,6 +54,7 @@ Library
      Data.IntervalSet
      Data.IntegerInterval
   Other-Modules:
+     Data.Interval.Internal
      Data.IntervalMap.Base
 
 Test-suite test-interval

--- a/src/Data/Interval.hs
+++ b/src/Data/Interval.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wall #-}
-{-# LANGUAGE CPP, ScopedTypeVariables, DeriveDataTypeable #-}
+{-# LANGUAGE CPP, ScopedTypeVariables, DeriveDataTypeable, DeriveGeneric #-}
 {-# LANGUAGE Safe #-}
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE RoleAnnotations #-}
@@ -89,6 +89,7 @@ import Data.List hiding (null)
 import Data.Maybe
 import Data.Monoid
 import Data.Ratio
+import GHC.Generics (Generic)
 import Prelude hiding (null)
 
 infix 5 <=..<=
@@ -115,48 +116,22 @@ infix 4 >??
 infix 4 /=??
 
 -- | The intervals (/i.e./ connected and convex subsets) over real numbers __R__.
-data Interval r = Interval !(Extended r, Bool) !(Extended r, Bool)
-  deriving (Eq, Typeable)
+data Interval r = Interval
+  { -- | 'lowerBound' of the interval and whether it is included in the interval.
+    -- The result is convenient to use as an argument for 'interval'.
+    lowerBound' :: !(Extended r, Bool)
+  , -- | 'upperBound' of the interval and whether it is included in the interval.
+    -- The result is convenient to use as an argument for 'interval'.
+    upperBound' :: !(Extended r, Bool)
+  } deriving (Eq, Generic, Data, Typeable)
 
 #if __GLASGOW_HASKELL__ >= 708
 type role Interval nominal
 #endif
 
--- | Lower endpoint (/i.e./ greatest lower bound)  of the interval.
---
--- * 'lowerBound' of the empty interval is 'PosInf'.
---
--- * 'lowerBound' of a left unbounded interval is 'NegInf'.
---
--- * 'lowerBound' of an interval may or may not be a member of the interval.
-lowerBound :: Interval r -> Extended r
-lowerBound (Interval (lb,_) _) = lb
+instance NFData r => NFData (Interval r)
 
--- | Upper endpoint (/i.e./ least upper bound) of the interval.
---
--- * 'upperBound' of the empty interval is 'NegInf'.
---
--- * 'upperBound' of a right unbounded interval is 'PosInf'.
---
--- * 'upperBound' of an interval may or may not be a member of the interval.
-upperBound :: Interval r -> Extended r
-upperBound (Interval _ (ub,_)) = ub
-
--- | 'lowerBound' of the interval and whether it is included in the interval.
--- The result is convenient to use as an argument for 'interval'.
-lowerBound' :: Interval r -> (Extended r, Bool)
-lowerBound' (Interval lb _) = lb
-
--- | 'upperBound' of the interval and whether it is included in the interval.
--- The result is convenient to use as an argument for 'interval'.
-upperBound' :: Interval r -> (Extended r, Bool)
-upperBound' (Interval _ ub) = ub
-
-instance NFData r => NFData (Interval r) where
-  rnf (Interval lb ub) = rnf lb `seq` rnf ub
-
-instance Hashable r => Hashable (Interval r) where
-  hashWithSalt s (Interval lb ub) = s `hashWithSalt` lb `hashWithSalt` ub
+instance Hashable r => Hashable (Interval r)
 
 instance (Ord r) => JoinSemiLattice (Interval r) where
   join = hull
@@ -176,12 +151,14 @@ instance (Ord r) => BoundedLattice (Interval r)
 
 instance (Ord r, Show r) => Show (Interval r) where
   showsPrec _ x | null x = showString "empty"
-  showsPrec p (Interval (lb,in1) (ub,in2)) =
+  showsPrec p i =
     showParen (p > rangeOpPrec) $
-      showsPrec (rangeOpPrec+1) lb . 
+      showsPrec (rangeOpPrec+1) lb .
       showChar ' ' . showString op . showChar ' ' .
       showsPrec (rangeOpPrec+1) ub
     where
+      (lb, in1) = lowerBound' i
+      (ub, in2) = upperBound' i
       op = (if in1 then "<=" else "<") ++ ".." ++ (if in2 then "<=" else "<")
 
 instance (Ord r, Read r) => Read (Interval r) where
@@ -208,23 +185,9 @@ instance (Ord r, Read r) => Read (Interval r) where
     (do ("empty", s) <- lex r
         return (empty, s))
 
--- This instance preserves data abstraction at the cost of inefficiency.
--- We provide limited reflection services for the sake of data abstraction.
-
-instance (Ord r, Data r) => Data (Interval r) where
-  gfoldl k z x   = z interval `k` lowerBound' x `k` upperBound' x
-  toConstr _     = intervalConstr
-  gunfold k z c  = case constrIndex c of
-    1 -> k (k (z interval))
-    _ -> error "gunfold"
-  dataTypeOf _   = intervalDataType
-  dataCast1 f    = gcast1 f
-
-intervalConstr :: Constr
-intervalConstr = mkConstr intervalDataType "interval" [] Prefix
-
-intervalDataType :: DataType
-intervalDataType = mkDataType "Data.Interval.Interval" [intervalConstr]
+-- | empty (contradicting) interval
+empty :: Ord r => Interval r
+empty = Interval (PosInf, False) (NegInf, False)
 
 -- | smart constructor for 'Interval'
 interval
@@ -240,6 +203,26 @@ interval lb@(x1,in1) ub@(x2,in2) =
   where
     normalize x@(Finite _, _) = x
     normalize (x, _) = (x, False)
+
+-- | Lower endpoint (/i.e./ greatest lower bound)  of the interval.
+--
+-- * 'lowerBound' of the empty interval is 'PosInf'.
+--
+-- * 'lowerBound' of a left unbounded interval is 'NegInf'.
+--
+-- * 'lowerBound' of an interval may or may not be a member of the interval.
+lowerBound :: Interval r -> Extended r
+lowerBound = fst . lowerBound'
+
+-- | Upper endpoint (/i.e./ least upper bound) of the interval.
+--
+-- * 'upperBound' of the empty interval is 'NegInf'.
+--
+-- * 'upperBound' of a right unbounded interval is 'PosInf'.
+--
+-- * 'upperBound' of an interval may or may not be a member of the interval.
+upperBound :: Interval r -> Extended r
+upperBound = fst . upperBound'
 
 -- | closed interval [@l@,@u@]
 (<=..<=)
@@ -275,11 +258,7 @@ interval lb@(x1,in1) ub@(x2,in2) =
 
 -- | whole real number line (-∞, ∞)
 whole :: Ord r => Interval r
-whole = Interval (NegInf, False) (PosInf, False)
-
--- | empty (contradicting) interval
-empty :: Ord r => Interval r
-empty = Interval (PosInf, False) (NegInf, False)
+whole = interval (NegInf, False) (PosInf, False)
 
 -- | singleton set \[x,x\]
 singleton :: Ord r => r -> Interval r
@@ -287,7 +266,9 @@ singleton x = interval (Finite x, True) (Finite x, True)
 
 -- | intersection of two intervals
 intersection :: forall r. Ord r => Interval r -> Interval r -> Interval r
-intersection (Interval l1 u1) (Interval l2 u2) = interval (maxLB l1 l2) (minUB u1 u2)
+intersection i1 i2 = interval
+  (maxLB (lowerBound' i1) (lowerBound' i2))
+  (minUB (upperBound' i1) (upperBound' i2))
   where
     maxLB :: (Extended r, Bool) -> (Extended r, Bool) -> (Extended r, Bool)
     maxLB (x1,in1) (x2,in2) =
@@ -317,7 +298,9 @@ hull :: forall r. Ord r => Interval r -> Interval r -> Interval r
 hull x1 x2
   | null x1 = x2
   | null x2 = x1
-hull (Interval l1 u1) (Interval l2 u2) = interval (minLB l1 l2) (maxUB u1 u2)
+hull i1 i2 = interval
+  (minLB (lowerBound' i1) (lowerBound' i2))
+  (maxUB (upperBound' i1) (upperBound' i2))
   where
     maxUB :: (Extended r, Bool) -> (Extended r, Bool) -> (Extended r, Bool)
     maxUB (x1,in1) (x2,in2) =
@@ -344,20 +327,26 @@ hulls = foldl' hull empty
 
 -- | Is the interval empty?
 null :: Ord r => Interval r -> Bool
-null (Interval (x1,in1) (x2,in2)) =
+null i =
   case x1 `compare` x2 of
     EQ -> assert (in1 && in2) False
     LT -> False
     GT -> True
+  where
+    (x1, in1) = lowerBound' i
+    (x2, in2) = upperBound' i
 
 isSingleton :: Ord r => Interval r -> Bool
-isSingleton (Interval (Finite l, True) (Finite u, True)) = l==u
-isSingleton _ = False
+isSingleton i = case (lowerBound' i, upperBound' i) of
+  ((Finite l, True), (Finite u, True)) -> l==u
+  _ -> False
 
 -- | Is the element in the interval?
 member :: Ord r => r -> Interval r -> Bool
-member x (Interval (x1,in1) (x2,in2)) = condLB && condUB
+member x i = condLB && condUB
   where
+    (x1, in1) = lowerBound' i
+    (x2, in2) = upperBound' i
     condLB = if in1 then x1 <= Finite x else x1 < Finite x
     condUB = if in2 then Finite x <= x2 else Finite x < x2
 
@@ -368,7 +357,7 @@ notMember a i = not $ member a i
 -- | Is this a subset?
 -- @(i1 \``isSubsetOf`\` i2)@ tells whether @i1@ is a subset of @i2@.
 isSubsetOf :: Ord r => Interval r -> Interval r -> Bool
-isSubsetOf (Interval lb1 ub1) (Interval lb2 ub2) = testLB lb1 lb2 && testUB ub1 ub2
+isSubsetOf i1 i2 = testLB (lowerBound' i1) (lowerBound' i2) && testUB (upperBound' i1) (upperBound' i2)
   where
     testLB (x1,in1) (x2,in2) =
       case x1 `compare` x2 of
@@ -401,21 +390,24 @@ isConnected x y
 
 -- | Width of a interval. Width of an unbounded interval is @undefined@.
 width :: (Num r, Ord r) => Interval r -> r
-width x | null x = 0
-width (Interval (Finite l, _) (Finite u, _)) = u - l
-width _ = error "Data.Interval.width: unbounded interval"
+width x
+  | null x = 0
+  | otherwise = case (fst (lowerBound' x), fst (upperBound' x)) of
+    (Finite l, Finite u) -> u - l
+    _ -> error "Data.Interval.width: unbounded interval"
 
 -- | pick up an element from the interval if the interval is not empty.
 pickup :: (Real r, Fractional r) => Interval r -> Maybe r
-pickup (Interval (NegInf,_) (PosInf,_))   = Just 0
-pickup (Interval (Finite x1, in1) (PosInf,_)) = Just $ if in1 then x1 else x1+1
-pickup (Interval (NegInf,_) (Finite x2, in2)) = Just $ if in2 then x2 else x2-1
-pickup (Interval (Finite x1, in1) (Finite x2, in2)) =
-  case x1 `compare` x2 of
-    GT -> Nothing
-    LT -> Just $ (x1+x2) / 2
-    EQ -> if in1 && in2 then Just x1 else Nothing
-pickup _ = Nothing
+pickup i = case (lowerBound' i, upperBound' i) of
+  ((NegInf,_), (PosInf,_))             -> Just 0
+  ((Finite x1, in1), (PosInf,_))       -> Just $ if in1 then x1 else x1+1
+  ((NegInf,_), (Finite x2, in2))       -> Just $ if in2 then x2 else x2-1
+  ((Finite x1, in1), (Finite x2, in2)) ->
+    case x1 `compare` x2 of
+      GT -> Nothing
+      LT -> Just $ (x1+x2) / 2
+      EQ -> if in1 && in2 then Just x1 else Nothing
+  _ -> Nothing
 
 -- | 'simplestRationalWithin' returns the simplest rational number within the interval.
 --
@@ -605,16 +597,20 @@ rangeOpPrec :: Int
 rangeOpPrec = 5
 
 scaleInterval :: (Num r, Ord r) => r -> Interval r -> Interval r
-scaleInterval _ x | null x = empty
-scaleInterval c (Interval lb ub) =
-  case compare c 0 of
+scaleInterval c x
+  | null x = empty
+  | otherwise = case compare c 0 of
     EQ -> singleton 0
     LT -> interval (scaleInf' c ub) (scaleInf' c lb)
     GT -> interval (scaleInf' c lb) (scaleInf' c ub)
+  where
+    lb = lowerBound' x
+    ub = upperBound' x
 
 instance (Num r, Ord r) => Num (Interval r) where
-  a + b | null a || null b = empty
-  Interval lb1 ub1 + Interval lb2 ub2 = interval (f lb1 lb2) (g ub1 ub2)
+  a + b
+    | null a || null b = empty
+    | otherwise = interval (f (lowerBound' a) (lowerBound' b)) (g (upperBound' a) (upperBound' b))
     where
       f (Finite x1, in1) (Finite x2, in2) = (Finite (x1+x2), in1 && in2)
       f (NegInf,_) _ = (-inf, False)
@@ -644,22 +640,24 @@ instance (Num r, Ord r) => Num (Interval r) where
             then empty
             else singleton (-1)
 
-  a * b | null a || null b = empty
-  Interval lb1 ub1 * Interval lb2 ub2 = interval lb3 ub3
+  a * b
+    | null a || null b = empty
+    | otherwise = interval lb3 ub3
     where
-      xs = [ mulInf' x1 x2 | x1 <- [lb1, ub1], x2 <- [lb2, ub2] ]
+      xs = [ mulInf' x1 x2 | x1 <- [lowerBound' a, upperBound' a], x2 <- [lowerBound' b, upperBound' b] ]
       ub3 = maximumBy cmpUB xs
       lb3 = minimumBy cmpLB xs
 
 instance forall r. (Real r, Fractional r) => Fractional (Interval r) where
   fromRational r = singleton (fromRational r)
-  recip a | null a = empty
-  recip i | 0 `member` i = whole -- should be error?
-  recip (Interval lb ub) = interval lb3 ub3
+  recip a
+    | null a = empty
+    | 0 `member` a = whole -- should be error?
+    | otherwise = interval lb3 ub3
     where
       ub3 = maximumBy cmpUB xs
       lb3 = minimumBy cmpLB xs
-      xs = [recipLB lb, recipUB ub]
+      xs = [recipLB (lowerBound' a), recipUB (upperBound' a)]
 
 cmpUB, cmpLB :: Ord r => (Extended r, Bool) -> (Extended r, Bool) -> Ordering
 cmpUB (x1,in1) (x2,in2) = compare x1 x2 `mappend` compare in1 in2

--- a/src/Data/Interval/Internal.hs
+++ b/src/Data/Interval/Internal.hs
@@ -1,0 +1,58 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE Safe #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE RoleAnnotations #-}
+#endif
+
+module Data.Interval.Internal
+  ( Interval
+  , lowerBound'
+  , upperBound'
+  , interval
+  , empty
+  ) where
+
+import Control.DeepSeq
+import Data.Data
+import Data.ExtendedReal
+import Data.Hashable
+import GHC.Generics (Generic)
+
+-- | The intervals (/i.e./ connected and convex subsets) over real numbers __R__.
+data Interval r = Interval
+  { -- | 'lowerBound' of the interval and whether it is included in the interval.
+    -- The result is convenient to use as an argument for 'interval'.
+    lowerBound' :: !(Extended r, Bool)
+  , -- | 'upperBound' of the interval and whether it is included in the interval.
+    -- The result is convenient to use as an argument for 'interval'.
+    upperBound' :: !(Extended r, Bool)
+  } deriving (Eq, Generic, Data, Typeable)
+
+#if __GLASGOW_HASKELL__ >= 708
+type role Interval nominal
+#endif
+
+instance NFData r => NFData (Interval r)
+
+instance Hashable r => Hashable (Interval r)
+
+-- | empty (contradicting) interval
+empty :: Ord r => Interval r
+empty = Interval (PosInf, False) (NegInf, False)
+
+-- | smart constructor for 'Interval'
+interval
+  :: (Ord r)
+  => (Extended r, Bool) -- ^ lower bound and whether it is included
+  -> (Extended r, Bool) -- ^ upper bound and whether it is included
+  -> Interval r
+interval lb@(x1,in1) ub@(x2,in2) =
+  case x1 `compare` x2 of
+    GT -> empty --  empty interval
+    LT -> Interval (normalize lb) (normalize ub)
+    EQ -> if in1 && in2 && isFinite x1 then Interval lb ub else empty
+  where
+    normalize x@(Finite _, _) = x
+    normalize (x, _) = (x, False)
+

--- a/src/Data/Interval/Internal.hs
+++ b/src/Data/Interval/Internal.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wall #-}
-{-# LANGUAGE CPP, DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE CPP, DeriveDataTypeable #-}
 {-# LANGUAGE Safe #-}
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE RoleAnnotations #-}
@@ -17,7 +17,6 @@ import Control.DeepSeq
 import Data.Data
 import Data.ExtendedReal
 import Data.Hashable
-import GHC.Generics (Generic)
 
 -- | The intervals (/i.e./ connected and convex subsets) over real numbers __R__.
 data Interval r = Interval
@@ -27,15 +26,32 @@ data Interval r = Interval
   , -- | 'upperBound' of the interval and whether it is included in the interval.
     -- The result is convenient to use as an argument for 'interval'.
     upperBound' :: !(Extended r, Bool)
-  } deriving (Eq, Generic, Data, Typeable)
+  } deriving (Eq, Typeable)
 
 #if __GLASGOW_HASKELL__ >= 708
 type role Interval nominal
 #endif
 
-instance NFData r => NFData (Interval r)
+instance (Ord r, Data r) => Data (Interval r) where
+  gfoldl k z x   = z interval `k` lowerBound' x `k` upperBound' x
+  toConstr _     = intervalConstr
+  gunfold k z c  = case constrIndex c of
+    1 -> k (k (z interval))
+    _ -> error "gunfold"
+  dataTypeOf _   = intervalDataType
+  dataCast1 f    = gcast1 f
 
-instance Hashable r => Hashable (Interval r)
+intervalConstr :: Constr
+intervalConstr = mkConstr intervalDataType "interval" [] Prefix
+
+intervalDataType :: DataType
+intervalDataType = mkDataType "Data.Interval.Internal.Interval" [intervalConstr]
+
+instance NFData r => NFData (Interval r) where
+  rnf (Interval lb ub) = rnf lb `seq` rnf ub
+
+instance Hashable r => Hashable (Interval r) where
+  hashWithSalt s (Interval lb ub) = s `hashWithSalt` lb `hashWithSalt` ub
 
 -- | empty (contradicting) interval
 empty :: Ord r => Interval r


### PR DESCRIPTION
I've been playing with different implementations of `Interval` and it appeared to be useful to do not pattern-match on `Interval` constructor in the body of the module, relying solely on `lowerBound'` / `upperBound'` / `empty` / `interval`.

It would be even better to move definition of `Interval` to a separate module, but it is difficult because of `Lattice` instances.

What is your opinion on this?