### PR TITLE
Travis: add GHC 8.6 to a build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ matrix:
     - env: CABALVER=2.0 GHCVER=8.2.2
       compiler: ": #GHC 8.2.2"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=2.0 GHCVER=8.4.3
-      compiler: ": #GHC 8.4.3"
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.4.3,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.4.4
+      compiler: ": #GHC 8.4.4"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.4.4,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.6.4
+      compiler: ": #GHC 8.6.4"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.6.4,alex-3.1.7,happy-1.19.5], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/data-interval.cabal
+++ b/data-interval.cabal
@@ -23,7 +23,8 @@ Tested-With:
    GHC ==7.10.3
    GHC ==8.0.2
    GHC ==8.2.2
-   GHC ==8.4.3
+   GHC ==8.4.4
+   GHC ==8.6.4
 
 source-repository head
   type:     git


### PR DESCRIPTION
Just a straightforward update of `.travis.yml`.