### PR TITLE
Reduce memory footprint

### DIFF
--- a/src/Data/Interval/Internal.hs
+++ b/src/Data/Interval/Internal.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wall #-}
-{-# LANGUAGE CPP, DeriveDataTypeable, LambdaCase #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, DeriveGeneric, LambdaCase #-}
 {-# LANGUAGE Safe #-}
 #if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE RoleAnnotations #-}
@@ -17,6 +17,7 @@ import Control.DeepSeq
 import Data.Data
 import Data.ExtendedReal
 import Data.Hashable
+import GHC.Generics (Generic)
 
 data Interval r
   = Whole
@@ -30,7 +31,7 @@ data Interval r
   | LeftOpen !r !r
   | RightOpen !r !r
   | Open !r !r
-  deriving (Eq, Typeable)
+  deriving (Eq, Generic, Typeable)
 
 lowerBound' :: Interval r -> (Extended r, Bool)
 lowerBound' = \case
@@ -79,33 +80,9 @@ intervalConstr = mkConstr intervalDataType "interval" [] Prefix
 intervalDataType :: DataType
 intervalDataType = mkDataType "Data.Interval.Internal.Interval" [intervalConstr]
 
-instance NFData r => NFData (Interval r) where
-  rnf = \case
-    Whole            -> ()
-    Empty            -> ()
-    Point r          -> rnf r
-    LessThan r       -> rnf r
-    LessOrEqual r    -> rnf r
-    GreaterThan r    -> rnf r
-    GreaterOrEqual r -> rnf r
-    Closed p q       -> rnf p `seq` rnf q
-    LeftOpen p q     -> rnf p `seq` rnf q
-    RightOpen p q    -> rnf p `seq` rnf q
-    Open p q         -> rnf p `seq` rnf q
+instance NFData r => NFData (Interval r)
 
-instance Hashable r => Hashable (Interval r) where
-  hashWithSalt s = \case
-    Whole            -> s `hashWithSalt`  (1 :: Int)
-    Empty            -> s `hashWithSalt`  (2 :: Int)
-    Point r          -> s `hashWithSalt`  (3 :: Int) `hashWithSalt` r
-    LessThan r       -> s `hashWithSalt`  (4 :: Int) `hashWithSalt` r
-    LessOrEqual r    -> s `hashWithSalt`  (5 :: Int) `hashWithSalt` r
-    GreaterThan r    -> s `hashWithSalt`  (6 :: Int) `hashWithSalt` r
-    GreaterOrEqual r -> s `hashWithSalt`  (7 :: Int) `hashWithSalt` r
-    Closed p q       -> s `hashWithSalt`  (8 :: Int) `hashWithSalt` p `hashWithSalt` q
-    LeftOpen p q     -> s `hashWithSalt`  (9 :: Int) `hashWithSalt` p `hashWithSalt` q
-    RightOpen p q    -> s `hashWithSalt` (10 :: Int) `hashWithSalt` p `hashWithSalt` q
-    Open p q         -> s `hashWithSalt` (11 :: Int) `hashWithSalt` p `hashWithSalt` q
+instance Hashable r => Hashable (Interval r)
 
 -- | empty (contradicting) interval
 empty :: Ord r => Interval r


### PR DESCRIPTION
Current representation of `Interval` takes 17 machine words to store a single `Interval Double`:

* `Extended Double` takes 3 words: tag, pointer to `Double` and `Double` itself.
* `(Extended Double, Bool)` takes 1+2+3+1 = 7 words: tag, two pointers, `Extended Double` and `Bool`.
* Finally, `Interval Double` takes 1+2+7+7 = 17 words: tag, two pointers, two tuples.

Spending 17 words per interval may be considered wasteful for some applications.

---

This PR features a new representation of `Interval`, such that `Interval Double` takes up to 7 machine words, which is 2.5x smaller memory footprint. 

This representation also allows to write an instance of `Data.Vector.Unboxed`, which will require only (2 words + 1 byte) per value. (I cannot include it into PR, because currently `data-interval` does not depend on `vector`).