### PR TITLE
Make lattices an optional dependency

### DIFF
--- a/data-interval.cabal
+++ b/data-interval.cabal
@@ -30,18 +30,24 @@ source-repository head
   type:     git
   location: git://github.com/msakai/data-interval.git
 
+flag lattices
+  description: Derive lattice instances
+  default: True
+
 Library
   Hs-source-dirs: src
   Build-Depends:
        base >=4 && <5
      , containers
-     , lattices >=1.2.1.1 && <2.1
      , deepseq
      , hashable >=1.1.2.5 && <1.4
      , extended-reals >=0.2 && <1.0
   if impl(ghc <8.0)
     Build-depends:
       semigroups
+  if flag(lattices)
+    build-depends:
+     lattices >=1.2.1.1 && <2.1
   Default-Language: Haskell2010
   Other-Extensions:
      CPP

--- a/src/Data/IntegerInterval.hs
+++ b/src/Data/IntegerInterval.hs
@@ -83,7 +83,9 @@ module Data.IntegerInterval
   , relate
   ) where
 
+#if MIN_VERSION_lattices
 import Algebra.Lattice
+#endif
 import Control.Exception (assert)
 import Control.Monad hiding (join)
 import Data.ExtendedReal
@@ -133,6 +135,7 @@ upperBound' x =
     ub@(Finite _) -> (ub, Closed)
     ub@_ -> (ub, Open)
 
+#if MIN_VERSION_lattices
 #if MIN_VERSION_lattices(2,0,0)
 
 instance Lattice IntegerInterval where
@@ -163,6 +166,7 @@ instance BoundedMeetSemiLattice IntegerInterval where
 
 instance BoundedLattice IntegerInterval
 
+#endif
 #endif
 
 instance Show IntegerInterval where

--- a/src/Data/Interval.hs
+++ b/src/Data/Interval.hs
@@ -82,7 +82,9 @@ module Data.Interval
   , relate
   ) where
 
+#if MIN_VERSION_lattices
 import Algebra.Lattice
+#endif
 import Control.Exception (assert)
 import Control.Monad hiding (join)
 import Data.ExtendedReal
@@ -117,6 +119,7 @@ infix 4 >=??
 infix 4 >??
 infix 4 /=??
 
+#if MIN_VERSION_lattices
 #if MIN_VERSION_lattices(2,0,0)
 
 instance (Ord r) => Lattice (Interval r) where
@@ -147,6 +150,7 @@ instance (Ord r) => BoundedMeetSemiLattice (Interval r) where
 
 instance (Ord r) => BoundedLattice (Interval r)
 
+#endif
 #endif
 
 instance (Ord r, Show r) => Show (Interval r) where

--- a/src/Data/IntervalSet.hs
+++ b/src/Data/IntervalSet.hs
@@ -62,7 +62,9 @@ module Data.IntervalSet
   where
 
 import Prelude hiding (null, span)
+#if MIN_VERSION_lattices
 import Algebra.Lattice
+#endif
 import Control.DeepSeq
 import Data.Data
 import Data.ExtendedReal
@@ -131,6 +133,7 @@ instance NFData r => NFData (IntervalSet r) where
 instance Hashable r => Hashable (IntervalSet r) where
   hashWithSalt s (IntervalSet m) = hashWithSalt s (Map.toList m)
 
+#if MIN_VERSION_lattices
 #if MIN_VERSION_lattices(2,0,0)
 
 instance (Ord r) => Lattice (IntervalSet r) where
@@ -161,6 +164,7 @@ instance (Ord r) => BoundedMeetSemiLattice (IntervalSet r) where
 
 instance (Ord r) => BoundedLattice (IntervalSet r)
 
+#endif
 #endif
 
 instance Ord r => Monoid (IntervalSet r) where

--- a/test/TestIntegerInterval.hs
+++ b/test/TestIntegerInterval.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE TemplateHaskell, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, TemplateHaskell, ScopedTypeVariables #-}
 module TestIntegerInterval (integerIntervalTestGroup) where
 
+#if MIN_VERSION_lattices
 import qualified Algebra.Lattice as L
+#endif
 import Control.DeepSeq
 import Control.Monad
 import Data.Generics.Schemes
@@ -722,6 +724,8 @@ prop_negate_negate =
   Lattice
 --------------------------------------------------------------------}
 
+#if MIN_VERSION_lattices
+
 prop_Lattice_Leq_welldefined =
   forAll integerIntervals $ \a b ->
     a `L.meetLeq` b == a `L.joinLeq` b
@@ -733,6 +737,14 @@ prop_top =
 prop_bottom =
   forAll integerIntervals $ \a ->
     L.bottom `L.joinLeq` a
+
+#else
+
+prop_Lattice_Leq_welldefined = True
+prop_top                     = True
+prop_bottom                  = True
+
+#endif
 
 {--------------------------------------------------------------------
   Read

--- a/test/TestInterval.hs
+++ b/test/TestInterval.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE TemplateHaskell, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, TemplateHaskell, ScopedTypeVariables #-}
 module TestInterval (intervalTestGroup) where
 
+#if MIN_VERSION_lattices
 import qualified Algebra.Lattice as L
+#endif
 import Control.DeepSeq
 import Control.Monad
 import Data.Generics.Schemes
@@ -827,6 +829,8 @@ prop_recip_zero =
   Lattice
 --------------------------------------------------------------------}
 
+#if MIN_VERSION_lattices
+
 prop_Lattice_Leq_welldefined =
   forAll intervals $ \a b ->
     a `L.meetLeq` b == a `L.joinLeq` b
@@ -838,6 +842,14 @@ prop_top =
 prop_bottom =
   forAll intervals $ \a ->
     L.bottom `L.joinLeq` a
+
+#else
+
+prop_Lattice_Leq_welldefined = True
+prop_top                     = True
+prop_bottom                  = True
+
+#endif
 
 {--------------------------------------------------------------------
   Read

--- a/test/TestIntervalSet.hs
+++ b/test/TestIntervalSet.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE TemplateHaskell, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, TemplateHaskell, ScopedTypeVariables #-}
 module TestIntervalSet (intervalSetTestGroup) where
 
+#if MIN_VERSION_lattices
 import qualified Algebra.Lattice as L
+#endif
 import Control.Applicative ((<$>))
 import Control.DeepSeq
 import Control.Monad
@@ -295,6 +297,8 @@ prop_Eq_reflexive =
   Lattice
 --------------------------------------------------------------------}
 
+#if MIN_VERSION_lattices
+
 prop_Lattice_Leq_welldefined =
   forAll arbitrary $ \(a :: IntervalSet Rational) (b :: IntervalSet Rational) ->
     a `L.meetLeq` b == a `L.joinLeq` b
@@ -306,6 +310,14 @@ prop_top =
 prop_bottom =
   forAll arbitrary $ \(a :: IntervalSet Rational) ->
     L.bottom `L.joinLeq` a
+
+#else
+
+prop_Lattice_Leq_welldefined = True
+prop_top                     = True
+prop_bottom                  = True
+
+#endif
 
 {--------------------------------------------------------------------
   Show / Read


### PR DESCRIPTION
`lattices` are a pretty heavy dependency and are sometimes difficult to build in experimental environments. This PR makes it an optional one by introducing a package flag.