### PR TITLE
Amend recip so that recip (recip xs) == xs // {0}

### DIFF
--- a/src/Data/IntervalSet.hs
+++ b/src/Data/IntervalSet.hs
@@ -220,9 +220,10 @@ instance (Num r, Ord r) => Num (IntervalSet r) where
       ]
     return y
 
+-- | @recip (recip xs) == delete 0 xs@
 instance forall r. (Real r, Fractional r) => Fractional (IntervalSet r) where
   fromRational r = singleton (fromRational r)
-  recip = lift1 recip
+  recip xs = lift1 recip (delete (Interval.singleton 0) xs)
 
 #if __GLASGOW_HASKELL__ >= 708
 instance Ord r => GHCExts.IsList (IntervalSet r) where

--- a/test/TestIntervalSet.hs
+++ b/test/TestIntervalSet.hs
@@ -455,9 +455,8 @@ prop_recip_singleton =
         d = fromIntegral (denominator r)
     in fromRational n / fromRational d == (fromRational (r::Rational) :: IntervalSet Rational)
 
-prop_recip_zero =
-  forAll arbitrary $ \(a :: IntervalSet Rational) ->
-    0 `IntervalSet.member` a ==> recip a == IntervalSet.whole
+prop_recip (a :: IntervalSet Rational) =
+  recip (recip a) === IntervalSet.delete (Interval.singleton 0) a
 
 {- ------------------------------------------------------------------
   Data


### PR DESCRIPTION
I was surprised to learn the behaviour of `recip` on intervals, containing 0:

```
recip [0,2]  = whole 
recip [-2,0] = whole 
recip [-2,2] = whole 
```

I'd expect that 

```
recip [0,2]  = [1/2,+Inf)
recip [-2,0] = (-Inf,-1/2]
recip [-2,2] = (-Inf,-1/2] + [1/2, +Inf)
```

This expectation can be expressed as a property
```
recip (recip xs) == xs // {0}
```

The PR amends instances of `Fractional` for `Interval` and `IntervalSet` to comply with the property above. The instance for `IntervalSet` remains total. The instance for `Interval` throws `DivideByZero`, when `0` is an interior point (because in this case `xs // {0}` is not an interval but two adjacent intervals).