### PR TITLE
Relation failure

### DIFF
--- a/src/Data/Interval.hs
+++ b/src/Data/Interval.hs
@@ -709,7 +709,7 @@ relate i1 i2 =
                    | otherwise                      -> Contains
     -- neither `i1` nor `i2` is contained in the other
     (False, False) -> case ( null (i1 `intersection` i2)
-                           , lowerBound i1 <= lowerBound i2
+                           , upperBound' i1 <= upperBound' i2
                            , i1 `isConnected` i2
                            ) of
       (True , True , True ) -> JustBefore

--- a/test/TestInterval.hs
+++ b/test/TestInterval.hs
@@ -359,11 +359,11 @@ prop_relate_two_intervals_overlap =
     Interval.relate a b == Overlaps
 
 prop_relate_interval_starts_another =
-  forAll (nonEmptyIntervalPairs (\(lb1, _) (ub1, _) (lb2, _) (ub2, _) -> lb1 == lb2 && ub1 < ub2)) $ \(a, b) ->
+  forAll (nonEmptyIntervalPairs (\lb1 (ub1, _) lb2 (ub2, _) -> lb1 == lb2 && ub1 < ub2)) $ \(a, b) ->
     Interval.relate a b == Starts
 
 prop_relate_interval_finishes_another =
-  forAll (nonEmptyIntervalPairs (\(lb1, _) (ub1, _) (lb2, _) (ub2, _) -> lb1 > lb2 && ub1 == ub2)) $ \(a, b) ->
+  forAll (nonEmptyIntervalPairs (\(lb1, _) ub1 (lb2, _) ub2 -> lb1 > lb2 && ub1 == ub2)) $ \(a, b) ->
     Interval.relate a b == Finishes
 
 prop_relate_interval_contains_another =


### PR DESCRIPTION
I used `upperBound'` instead of `lowerBound` to use the derived order on `Boundary`

I corrected also two tests which were failing due to a too broad definition