### PR TITLE
Support base-4.15

### DIFF
--- a/src/Data/IntegerInterval.hs
+++ b/src/Data/IntegerInterval.hs
@@ -89,7 +89,7 @@ import Algebra.Lattice
 import Control.Exception (assert)
 import Control.Monad hiding (join)
 import Data.ExtendedReal
-import Data.List hiding (null)
+import Data.List (foldl')
 import Data.Maybe
 import Prelude hiding (null)
 import Data.IntegerInterval.Internal

--- a/src/Data/Interval.hs
+++ b/src/Data/Interval.hs
@@ -90,7 +90,7 @@ import Control.Monad hiding (join)
 import Data.ExtendedReal
 import Data.Interval.Internal
 import Data.IntervalRelation
-import Data.List hiding (null)
+import Data.List (foldl', maximumBy, minimumBy, partition)
 import Data.Maybe
 import Data.Monoid
 import Data.Ratio


### PR DESCRIPTION
`Data.List.singleton` from `base-4.15` conflicts with `Data.Interval.singleton`
https://downloads.haskell.org/ghc/9.0.1-rc1/docs/html/libraries/base-4.15.0.0/Data-List.html#v:singleton

`-Wcompat` recommends to import `Data.List` with explicit list.