### PR TITLE
Add Ord instances for Interval, IntervalSet and IntervalMap

### DIFF
--- a/src/Data/Interval/Internal.hs
+++ b/src/Data/Interval/Internal.hs
@@ -50,7 +50,14 @@ data Interval r
   | LeftOpen !r !r
   | RightOpen !r !r
   | BothOpen !r !r
-  deriving (Eq, Typeable)
+  deriving
+    ( Eq,
+      Ord,
+      -- ^ Note that this Ord is derived and not semantically meaningful.
+      -- The primary intended use case is to allow using 'Interval'
+      -- in maps and sets that require ordering.
+      Typeable
+    )
 
 peekInterval :: (Applicative m, Monad m, Ord r) => m Int8 -> m r -> m r -> m (Interval r)
 peekInterval tagM x y = do

--- a/src/Data/Interval/Internal.hs
+++ b/src/Data/Interval/Internal.hs
@@ -51,12 +51,12 @@ data Interval r
   | RightOpen !r !r
   | BothOpen !r !r
   deriving
-    ( Eq,
-      Ord,
+    ( Eq
+    , Ord
       -- ^ Note that this Ord is derived and not semantically meaningful.
       -- The primary intended use case is to allow using 'Interval'
       -- in maps and sets that require ordering.
-      Typeable
+    , Typeable
     )
 
 peekInterval :: (Applicative m, Monad m, Ord r) => m Int8 -> m r -> m r -> m (Interval r)

--- a/src/Data/IntervalMap/Base.hs
+++ b/src/Data/IntervalMap/Base.hs
@@ -115,7 +115,14 @@ import qualified GHC.Exts as GHCExts
 -- Unlike 'IntervalSet', 'IntervalMap' never merge adjacent mappings,
 -- even if adjacent intervals are connected and mapped to the same value.
 newtype IntervalMap r a = IntervalMap (Map (LB r) (Interval r, a))
-  deriving (Eq, Typeable)
+  deriving
+    ( Eq,
+      Ord,
+      -- ^ Note that this Ord is derived and not semantically meaningful.
+      -- The primary intended use case is to allow using 'IntervalSet'
+      -- in maps and sets that require ordering.
+      Typeable
+    )
 
 type role IntervalMap nominal representational
 

--- a/src/Data/IntervalMap/Base.hs
+++ b/src/Data/IntervalMap/Base.hs
@@ -116,12 +116,12 @@ import qualified GHC.Exts as GHCExts
 -- even if adjacent intervals are connected and mapped to the same value.
 newtype IntervalMap r a = IntervalMap (Map (LB r) (Interval r, a))
   deriving
-    ( Eq,
-      Ord,
+    ( Eq
+    , Ord
       -- ^ Note that this Ord is derived and not semantically meaningful.
       -- The primary intended use case is to allow using 'IntervalSet'
       -- in maps and sets that require ordering.
-      Typeable
+    , Typeable
     )
 
 type role IntervalMap nominal representational

--- a/src/Data/IntervalSet.hs
+++ b/src/Data/IntervalSet.hs
@@ -84,7 +84,14 @@ import qualified GHC.Exts as GHCExts
 --
 -- Any connected intervals are merged together, and empty intervals are ignored.
 newtype IntervalSet r = IntervalSet (Map (Extended r) (Interval r))
-  deriving (Eq, Typeable)
+  deriving
+    ( Eq,
+      Ord,
+      -- ^ Note that this Ord is derived and not semantically meaningful.
+      -- The primary intended use case is to allow using 'IntervalSet'
+      -- in maps and sets that require ordering.
+      Typeable
+    )
 
 type role IntervalSet nominal
 

--- a/src/Data/IntervalSet.hs
+++ b/src/Data/IntervalSet.hs
@@ -85,12 +85,12 @@ import qualified GHC.Exts as GHCExts
 -- Any connected intervals are merged together, and empty intervals are ignored.
 newtype IntervalSet r = IntervalSet (Map (Extended r) (Interval r))
   deriving
-    ( Eq,
-      Ord,
+    ( Eq
+    , Ord
       -- ^ Note that this Ord is derived and not semantically meaningful.
       -- The primary intended use case is to allow using 'IntervalSet'
       -- in maps and sets that require ordering.
-      Typeable
+    , Typeable
     )
 
 type role IntervalSet nominal


### PR DESCRIPTION
The primary intended use case for these is to allow storage in maps and sets.