### PR TITLE
IntegerInterval: add memberCount

### DIFF
--- a/src/Data/IntegerInterval.hs
+++ b/src/Data/IntegerInterval.hs
@@ -50,6 +50,7 @@ module Data.IntegerInterval
   , lowerBound'
   , upperBound'
   , width
+  , memberCount
 
   -- * Universal comparison operators
   , (<!), (<=!), (==!), (>=!), (>!), (/=!)
@@ -308,6 +309,17 @@ width x
       case (lowerBound x, upperBound x) of
         (Finite lb, Finite ub) -> ub - lb
         _ -> error "Data.IntegerInterval.width: unbounded interval"
+
+-- | How many integers lie within the (bounded) interval.
+-- Equal to @Just (width + 1)@ for non-empty, bounded intervals.
+-- The @memberCount@ of an unbounded interval is @Nothing@.
+memberCount :: IntegerInterval -> Maybe Integer
+memberCount x
+  | null x = Just 0
+  | otherwise =
+      case (lowerBound x, upperBound x) of
+        (Finite lb, Finite ub) -> Just (ub - lb + 1)
+        _ -> Nothing
 
 -- | pick up an element from the interval if the interval is not empty.
 pickup :: IntegerInterval -> Maybe Integer

--- a/test/TestIntegerInterval.hs
+++ b/test/TestIntegerInterval.hs
@@ -276,6 +276,20 @@ prop_width_singleton =
     IntegerInterval.width (IntegerInterval.singleton x) == 0
 
 {--------------------------------------------------------------------
+  memberCount
+--------------------------------------------------------------------}
+
+case_memberCount_null =
+  IntegerInterval.memberCount IntegerInterval.empty @?= Just 0
+
+case_memberCount_positive =
+  IntegerInterval.memberCount (0 <=..< 10) @?= Just 10
+
+prop_memberCount_singleton =
+  forAll arbitrary $ \x ->
+    IntegerInterval.memberCount (IntegerInterval.singleton x) == Just 1
+
+{--------------------------------------------------------------------
   map
 --------------------------------------------------------------------}
 


### PR DESCRIPTION
Returns the number of integers that lie within an integer interval.

This is different from the `width` and cannot simply be computed as `(+ 1) . width` because of the null interval.

Addresses https://github.com/msakai/data-interval/issues/39

**EDIT**: I initially named this `magnitude` because I misunderstood what `Numeric.Interval.magnitude` does. Feel free to suggest a better name.